### PR TITLE
CREST encoder now selects min(os.cpu_count(), 16) if threads not set …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [unreleased]
 
+### Changed
+
+- CREST encoder now selects `min(os.cpu_count(), 16)` for `threads` if not set by the user.
+
 ## [0.7.3] - 2025-02-08
 
 ### Fixed

--- a/qcparse/encoders/crest.py
+++ b/qcparse/encoders/crest.py
@@ -101,7 +101,7 @@ def _to_toml_dict(inp_obj: ProgramInput, struct_filename: str) -> dict[str, Any]
 
     # Top level keywords
     # Logical cores was 10% faster than physical cores, so not using psutil
-    toml_dict.setdefault("threads", os.cpu_count())
+    toml_dict.setdefault("threads", min(os.cpu_count() or 16, 16))
     toml_dict["input"] = struct_filename
 
     # Set default runtype if not already set


### PR DESCRIPTION
…by user.